### PR TITLE
mm/kmemleak: Use explicit cast to cast pointer from percpu to generic AS

### DIFF
--- a/mm/kmemleak.c
+++ b/mm/kmemleak.c
@@ -1059,8 +1059,9 @@ void __ref kmemleak_alloc_percpu(const void __percpu *ptr, size_t size,
 	 * Percpu allocations are only scanned and not reported as leaks
 	 * (min_count is set to 0).
 	 */
-	if (kmemleak_enabled && ptr && !IS_ERR(ptr))
-		create_object_percpu((unsigned long)ptr, size, 0, gfp);
+	if (kmemleak_enabled && ptr &&
+	    !IS_ERR((const void *)(__force const unsigned long)ptr))
+		create_object_percpu((__force unsigned long)ptr, size, 0, gfp);
 }
 EXPORT_SYMBOL_GPL(kmemleak_alloc_percpu);
 
@@ -1134,8 +1135,9 @@ void __ref kmemleak_free_percpu(const void __percpu *ptr)
 {
 	pr_debug("%s(0x%px)\n", __func__, ptr);
 
-	if (kmemleak_free_enabled && ptr && !IS_ERR(ptr))
-		delete_object_full((unsigned long)ptr, OBJECT_PERCPU);
+	if (kmemleak_free_enabled && ptr &&
+	    !IS_ERR((const void *)(__force const unsigned long)ptr))
+		delete_object_full((__force unsigned long)ptr, OBJECT_PERCPU);
 }
 EXPORT_SYMBOL_GPL(kmemleak_free_percpu);
 


### PR DESCRIPTION
Pull request for series with
subject: mm/kmemleak: Use explicit cast to cast pointer from percpu to generic AS
version: 2
url: https://patchwork.kernel.org/project/linux-mm/list/?series=880642
