### PR TITLE
ASoC: dt-bindings: samsung,odroid: drop stale clocks

### DIFF
--- a/Documentation/devicetree/bindings/sound/samsung,odroid.yaml
+++ b/Documentation/devicetree/bindings/sound/samsung,odroid.yaml
@@ -27,11 +27,6 @@ properties:
       - const: samsung,odroid-xu4-audio
         deprecated: true
 
-  assigned-clock-parents: true
-  assigned-clock-rates: true
-  assigned-clocks: true
-  clocks: true
-
   cpu:
     type: object
     additionalProperties: false


### PR DESCRIPTION
Pull request for series with
subject: ASoC: dt-bindings: samsung,odroid: drop stale clocks
version: 1
url: https://patchwork.kernel.org/project/alsa-devel/list/?series=880651
