### PR TITLE
dt-bindings: memory-controllers: renesas,rpc-if: add top-level constraints

### DIFF
--- a/Documentation/devicetree/bindings/memory-controllers/renesas,rpc-if.yaml
+++ b/Documentation/devicetree/bindings/memory-controllers/renesas,rpc-if.yaml
@@ -67,7 +67,9 @@ properties:
       - const: dirmap
       - const: wbuf
 
-  clocks: true
+  clocks:
+    minItems: 1
+    maxItems: 2
 
   interrupts:
     maxItems: 1


### PR DESCRIPTION
Pull request for series with
subject: dt-bindings: memory-controllers: renesas,rpc-if: add top-level constraints
version: 1
url: https://patchwork.kernel.org/project/linux-renesas-soc/list/?series=880655
